### PR TITLE
fix: linglong -> deepin-linglong

### DIFF
--- a/misc/dbus/org.deepin.linglong.PackageManager.conf
+++ b/misc/dbus/org.deepin.linglong.PackageManager.conf
@@ -6,7 +6,7 @@
 <busconfig>
 
   <!-- Only deepin-longlong can own the service -->
-  <policy user="linglong">
+  <policy user="deepin-linglong">
     <allow own="org.deepin.linglong.PackageManager"/>
   </policy>
 

--- a/misc/dbus/org.deepin.linglong.SystemHelper.conf
+++ b/misc/dbus/org.deepin.linglong.SystemHelper.conf
@@ -10,8 +10,8 @@
     <allow own="org.deepin.linglong.SystemHelper"/>
   </policy>
 
-  <!-- Only allow linglong to invoke methods on the interfaces -->
-  <policy user="linglong">
+  <!-- Only allow deepin-linglong to invoke methods on the interfaces -->
+  <policy user="deepin-linglong">
     <allow send_destination="org.deepin.linglong.SystemHelper"/>
   </policy>
 

--- a/misc/systemd/service/org.deepin.linglong.PackageManager.service.in
+++ b/misc/systemd/service/org.deepin.linglong.PackageManager.service.in
@@ -3,8 +3,8 @@ Description=Linglong dbus service
 
 [Service]
 Type=dbus
-User=linglong
-Group=linglong
+User=deepin-linglong
+Group=deepin-linglong
 BusName=org.deepin.linglong.PackageManager
 ExecStartPre=+@CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong/create-linglong-dirs
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/ll-package-manager

--- a/misc/sysuser/linglong.conf
+++ b/misc/sysuser/linglong.conf
@@ -6,4 +6,4 @@
 # at boot on systemd-based systems that ship with an unpopulated /etc/.
 # See sysuser.d(5) for details.
 
-u linglong - "linglong Package Manager"
+u deepin-linglong - "linglong Package Manager"


### PR DESCRIPTION
Close #27

"linglong" will be a frequently-used name of chinese. Let's back to
"deepin-linglong".

This commit partly revert 4be58ef48ba962a43bb4f35440fd55fa18749b3b.
