### PR TITLE
fix: make ll-cli repo modify work again

### DIFF
--- a/misc/scripts/create-linglong-dirs.in
+++ b/misc/scripts/create-linglong-dirs.in
@@ -12,10 +12,24 @@ LINGLONG_ROOT="@LINGLONG_ROOT@"
 LINGLONG_LOG_DIR="@LINGLONG_LOG_DIR@"
 LINGLONG_USERNAME="@LINGLONG_USERNAME@"
 
+function create_linglong_root(){
+    if [[ -d "$LINGLONG_ROOT" ]]; then
+        return
+    fi
 
-mkdir -p "$LINGLONG_ROOT"
-mkdir -p "$LINGLONG_LOG_DIR"
+    mkdir -p "$LINGLONG_ROOT"
+    chown "$LINGLONG_USERNAME:$LINGLONG_USERNAME" "$LINGLONG_ROOT"
+}
 
-chown "$LINGLONG_USERNAME:$LINGLONG_USERNAME" "$LINGLONG_ROOT"
-chown "$LINGLONG_USERNAME:$LINGLONG_USERNAME" "$LINGLONG_LOG_DIR"
-chmod o+w "$LINGLONG_LOG_DIR" # FIXME: remove this later.
+function create_linglong_log_dir(){
+    if [[ -d "$LINGLONG_LOG_DIR" ]]; then
+        return
+    fi
+
+    mkdir -p "$LINGLONG_LOG_DIR"
+    chown "$LINGLONG_USERNAME:$LINGLONG_USERNAME" "$LINGLONG_LOG_DIR"
+    chmod o+w "$LINGLONG_LOG_DIR" # FIXME: remove this later.
+}
+
+create_linglong_root
+create_linglong_log_dir

--- a/src/package_manager/impl/package_manager.cpp
+++ b/src/package_manager/impl/package_manager.cpp
@@ -1307,12 +1307,6 @@ Reply PackageManager::ModifyRepo(const QString &name, const QString &url)
         return reply;
     }
 
-    if (!linglong::util::fileExists(serverCfg)) {
-        reply.message = serverCfg + " no exist";
-        reply.code = STATUS_CODE(kErrorModifyRepoFailed);
-        return reply;
-    }
-
     QString dstUrl = "";
     if (url.endsWith("/")) {
         dstUrl = url + "repos/" + name;


### PR DESCRIPTION
ll-cli repo modify breaks after ef2317f819b4ed23a3d7f18379d2fbcb59fbdc11

QFile will create e file if it doesn't exist, so I just remove the
check.
