### PR TITLE
refactor: modify the application configuration file

### DIFF
--- a/misc/scripts/app-conf-generator.sh
+++ b/misc/scripts/app-conf-generator.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#set -x
+
+appId=$1
+appEntriesPath=$2
+
+desktopPath="${appEntriesPath}/share/applications"
+systemdServicePath="${appEntriesPath}/share/systemd/user"
+dbusServicePath="${appEntriesPath}/share/dbus-1"
+contextMenuPath="${appEntriesPath}/share/applications/context-menus"
+
+# replace 'Exec=XX' to 'Exec=ll-cli run ${appId} --exec "XX"'
+# warning: the XX will include a prefix such as "/usr/bin".
+ExecReplace()
+{
+    filePath=$1
+    fileType=$2
+    for path in `ls ${filePath}/${fileType}`
+    do
+        execContent=(`grep "^Exec=" ${path}`)
+        IFS=$'\n'
+        for content in ${execContent[@]}
+        do
+            if [[ "${content}" =~ "ll-cli run" ]];then
+                continue
+            fi
+            startByLinglong="Exec=ll-cli run ${appId} --exec ${content/Exec=}"
+            sed -i "s|${content}$|${startByLinglong}|g" ${path}
+        done
+    done
+}
+
+IconsReplace()
+{
+    echo "replace Icons"
+}
+
+DesktopGenerator()
+{   
+    ExecReplace ${desktopPath} "*.desktop"
+    #IconsReplace ${desktopPath} "*.desktop"
+}
+
+DBusServiceGenerator()
+{
+    ExecReplace ${dbusServicePath} "*.service"
+}
+
+SystemdServiceGenerator()
+{
+    ExecReplace ${systemdServicePath} "*.service"
+}
+
+ContextMenuGenerator()
+{
+    ExecReplace ${contextMenuPath} "*.conf"
+}
+
+main () 
+{
+    if [ -d "${desktopPath}" ]; then
+        DesktopGenerator
+    fi
+    if [ -d "${dbusServicePath}" ]; then
+        DBusServiceGenerator
+    fi
+    if [ -d "${systemdServicePath}" ]; then
+        SystemdServiceGenerator
+    fi
+    if [ -d "${contextMenuPath}" ]; then
+        ContextMenuGenerator
+    fi
+}
+
+main

--- a/src/builder/builder/linglong_builder.cpp
+++ b/src/builder/builder/linglong_builder.cpp
@@ -77,62 +77,9 @@ linglong::util::Error commitBuildOutput(Project *project, AnnotationsOverlayfsRo
     // FIXME: must wait fuse mount filesystem
     QThread::sleep(1);
 
-    auto entriesPath = project->config().cacheInstallPath("entries");
-
-    auto modifyConfigFile = [](const QString &srcPath,
-                               const QString &targetPath,
-                               const QString &fileType,
-                               const QString &appId) -> util::Error {
-        QDir configDir(srcPath);
-        auto configFileInfoList = configDir.entryInfoList({ fileType }, QDir::Files);
-
-        linglong::util::ensureDir(targetPath);
-
-        for (auto const &fileInfo : configFileInfoList) {
-            util::DesktopEntry desktopEntry(fileInfo.filePath());
-
-            // set all section
-            auto configSections = desktopEntry.sections();
-            for (auto section : configSections) {
-                auto exec = desktopEntry.rawValue("Exec", section);
-                exec = QString("ll-cli run %1 --exec '%2'").arg(appId, exec);
-                desktopEntry.set(section, "Exec", exec);
-
-                // The section TryExec affects starting from the launcher, set it to null.
-                auto tryExec = desktopEntry.rawValue("TryExec", section);
-
-                if (!tryExec.isEmpty()) {
-                    desktopEntry.set(section, "TryExec", "");
-                }
-                auto ret = desktopEntry.save(
-                        QStringList{ targetPath, fileInfo.fileName() }.join(QDir::separator()));
-                if (!ret.success()) {
-                    return WrapError(ret, "save config failed");
-                }
-            }
-        }
-        return NoError();
-    };
-
-    auto appId = project->package->id;
-    // modify desktop file
-    auto desktopFilePath = QStringList{ output, "share/applications" }.join(QDir::separator());
-    auto desktopFileSavePath = QStringList{ entriesPath, "applications" }.join(QDir::separator());
-    auto modifyRet = modifyConfigFile(desktopFilePath, desktopFileSavePath, "*.desktop", appId);
-    if (!modifyRet.success()) {
-        kill(fuseOverlayfsPid, SIGTERM);
-        return modifyRet;
-    }
-
-    // modify context-menus file
-    auto contextFilePath =
-            QStringList{ output, "share/applications/context-menus" }.join(QDir::separator());
-    auto contextFileSavePath = contextFilePath;
-    modifyRet = modifyConfigFile(contextFilePath, contextFileSavePath, "*.conf", appId);
-    if (!modifyRet.success()) {
-        kill(fuseOverlayfsPid, SIGTERM);
-        return modifyRet;
-    }
+    // copy files/share to entries/share
+    util::copyDir(project->config().cacheInstallPath("files/share"),
+                  project->config().cacheInstallPath("entries/share"));
 
     auto moveDir = [](const QStringList targetList,
                       const QString &srcPath,
@@ -149,13 +96,6 @@ linglong::util::Error commitBuildOutput(Project *project, AnnotationsOverlayfsRo
 
         return NoError();
     };
-
-    // link files/share to entries/share/
-    linglong::util::linkDirFiles(project->config().cacheInstallPath("files/share"), entriesPath);
-    // link files/lib/systemd to entries/systemd
-    linglong::util::linkDirFiles(
-            project->config().cacheInstallPath("files/lib/systemd/user"),
-            QStringList{ entriesPath, "systemd/user" }.join(QDir::separator()));
 
     // Move runtime-install/files/debug to devel-install/files/debug
     linglong::util::ensureDir(project->config().cacheInstallPath("devel-install", "files"));

--- a/src/package_manager/CMakeLists.txt
+++ b/src/package_manager/CMakeLists.txt
@@ -53,6 +53,7 @@ set(LL_SYSTEM_SERVICE_SOURCES
     impl/package_manager.cpp
     impl/package_manager_flatpak_impl.cpp
     main.cpp
+    resource.qrc
 )
 
 qt5_add_dbus_adaptor(

--- a/src/package_manager/resource.qrc
+++ b/src/package_manager/resource.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file alias="app-conf-generator.sh">../../misc/scripts/app-conf-generator.sh</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
Some paths may not be determined at build time, so we should let the changes be handled during the installation process.

Log: