### PR TITLE
fix: Unable to get the latest local ref

### DIFF
--- a/src/module/repo/ostree_repo.cpp
+++ b/src/module/repo/ostree_repo.cpp
@@ -895,7 +895,7 @@ package::Ref OSTreeRepo::localLatestRef(const package::Ref &ref)
 
     QString latestVer = "latest";
 
-    QString args = QString("ostree refs repo --repo=%1 | grep %2 | grep %3")
+    QString args = QString("ostree refs --repo=%1 | grep %2 | grep %3")
                            .arg(d->ostreePath)
                            .arg(ref.appId)
                            .arg(util::hostArch() + "/" + "runtime");


### PR DESCRIPTION
命令行多加了一个参数,ostree会返回空内容,无法正确获取本地最新分支

Log: