### PR TITLE
feat: builder add offline parameter

### DIFF
--- a/src/builder/builder/builder_config.cpp
+++ b/src/builder/builder/builder_config.cpp
@@ -82,6 +82,16 @@ QString BuilderConfig::getExec() const
     return exec;
 }
 
+void BuilderConfig::setOffline(const bool &offlineParam)
+{
+    offline = offlineParam;
+}
+
+bool BuilderConfig::getOffline() const
+{
+    return offline;
+}
+
 QString BuilderConfig::templatePath() const
 {
     for (auto dataPath : QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation)) {

--- a/src/builder/builder/builder_config.h
+++ b/src/builder/builder/builder_config.h
@@ -47,6 +47,9 @@ public:
     void setExec(const QString &exec);
     QString getExec() const;
 
+    void setOffline(const bool &exec);
+    bool getOffline() const;
+
     // TODO: remove later
     QString targetFetchCachePath() const;
 
@@ -59,6 +62,7 @@ private:
     QString projectRoot;
     QString projectName;
     QString exec;
+    bool offline;
 };
 
 } // namespace builder

--- a/src/builder/builder/depend_fetcher.cpp
+++ b/src/builder/builder/depend_fetcher.cpp
@@ -59,15 +59,23 @@ linglong::util::Error DependFetcher::fetch(const QString &subPath, const QString
                                  dd_ptr->ref.version,
                                  dd_ptr->ref.arch,
                                  "");
-        dependRef = ostree.remoteLatestRef(dependRef);
+        if (BuilderConfig::instance()->getOffline()) {
+            dependRef = ostree.localLatestRef(dependRef);
 
-        qInfo() << QString("fetching dependency: %1 %2")
-                           .arg(dependRef.appId)
-                           .arg(dependRef.version);
+            qInfo() << QString("offline dependency: %1 %2")
+                            .arg(dependRef.appId)
+                            .arg(dependRef.version);
+        } else {
+            dependRef = ostree.remoteLatestRef(dependRef);
 
-        ret = ostree.pullAll(dependRef, true);
-        if (!ret.success()) {
-            return WrapError(ret, "pull " + dependRef.toString() + " failed");
+            qInfo() << QString("fetching dependency: %1 %2")
+                            .arg(dependRef.appId)
+                            .arg(dependRef.version);
+
+            ret = ostree.pullAll(dependRef, true);
+            if (!ret.success()) {
+                return WrapError(ret, "pull " + dependRef.toString() + " failed");
+            }
         }
     }
 

--- a/src/builder/builder/depend_fetcher.cpp
+++ b/src/builder/builder/depend_fetcher.cpp
@@ -59,6 +59,13 @@ linglong::util::Error DependFetcher::fetch(const QString &subPath, const QString
                                  dd_ptr->ref.version,
                                  dd_ptr->ref.arch,
                                  "");
+
+        // FIXME(black_desk):
+        // 1. We should not use ostree repo in ll-builder, we should use the
+        //    repo interface;
+        // 2. Offline should not only be an option of builder, but also a work
+        //    mode argument passed to repo, which prevent all network request.
+        // 3. For now we just leave these code here, we will refactor them later.
         if (BuilderConfig::instance()->getOffline()) {
             dependRef = ostree.localLatestRef(dependRef);
 

--- a/src/builder/main.cpp
+++ b/src/builder/main.cpp
@@ -101,10 +101,12 @@ int main(int argc, char **argv)
               auto srcVersion =
                       QCommandLineOption("sversion", "set source version", "source version");
               auto srcCommit = QCommandLineOption("commit", "set commit refs", "source commit");
+              auto buildOffline = QCommandLineOption("offline", "only use local repo", "");
               parser.addOption(execVerbose);
               parser.addOption(pkgVersion);
               parser.addOption(srcVersion);
               parser.addOption(srcCommit);
+              parser.addOption(buildOffline);
 
               parser.addPositionalArgument("build", "build project", "build");
 
@@ -113,6 +115,8 @@ int main(int argc, char **argv)
               if (parser.isSet(execVerbose)) {
                   linglong::builder::BuilderConfig::instance()->setExec(parser.value(execVerbose));
               }
+              linglong::builder::BuilderConfig::instance()->setOffline(parser.isSet(buildOffline));
+              
               // config linglong.yaml before build if necessary
               if (parser.isSet(pkgVersion) || parser.isSet(srcVersion) || parser.isSet(srcCommit)) {
                   auto projectConfigPath =


### PR DESCRIPTION
支持离线构建参数,启用时不会再查询和拉取远程仓库

Log: