### PR TITLE
feat: add a section to the desktop entry

### DIFF
--- a/src/builder/builder/linglong_builder.cpp
+++ b/src/builder/builder/linglong_builder.cpp
@@ -106,6 +106,9 @@ linglong::util::Error commitBuildOutput(Project *project, AnnotationsOverlayfsRo
                 if (!tryExec.isEmpty()) {
                     desktopEntry.set(section, "TryExec", "");
                 }
+
+                desktopEntry.set(section, "X-linglong", appId);
+
                 auto ret = desktopEntry.save(
                         QStringList{ targetPath, fileInfo.fileName() }.join(QDir::separator()));
                 if (!ret.success()) {


### PR DESCRIPTION
Add 'X-linglong=${appId}' to the desktop entry to indicate
 that this is a linglong application.

Log: