### PR TITLE
blakc desk/bump version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+linglong (1.3.7-1) unstable; urgency=medium
+
+  This release include some important backports:
+
+  * feat: builder add offline parameter
+  * fix: Unable to get the latest local ref
+  * feat: add a section to the desktop entry
+
+ -- chenlinxuan <chenlinxuan@uniontech.com>  Mon, 03 Apr 2023 17:25:33 +0800
+
 linglong (1.3.6-1) unstable; urgency=medium
 
   1.3.x versions will be maintained to be work on deepin/uos v20 based


### PR DESCRIPTION
- Revert "fix: some parameter of exec parsing failed"
- chore: bump version to 1.3.6
- feat: add a section to the desktop entry
- fix: Unable to get the latest local ref
- feat: builder add offline parameter
- chore: bump version to 1.3.7
