### PR TITLE
fix: return with error info in getLatestRemoteRef

### DIFF
--- a/src/builder/builder/depend_fetcher.cpp
+++ b/src/builder/builder/depend_fetcher.cpp
@@ -73,11 +73,15 @@ linglong::util::Error DependFetcher::fetch(const QString &subPath, const QString
                             .arg(dependRef.appId)
                             .arg(dependRef.version);
         } else {
-            dependRef = ostree.remoteLatestRef(dependRef);
+            auto result = ostree.remoteLatestRef(dependRef);
+            dependRef = std::get<1>(result);
+
+            if (!std::get<0>(result).success())
+                return WrapError(std::get<0>(result), "call remoteLatestRef failed");
 
             qInfo() << QString("fetching dependency: %1 %2")
-                            .arg(dependRef.appId)
-                            .arg(dependRef.version);
+                               .arg(dependRef.appId)
+                               .arg(dependRef.version);
 
             ret = ostree.pullAll(dependRef, true);
             if (!ret.success()) {

--- a/src/builder/builder/linglong_builder.cpp
+++ b/src/builder/builder/linglong_builder.cpp
@@ -1048,8 +1048,8 @@ linglong::util::Error LinglongBuilder::run()
                                              project->runtimeRef().arch,
                                              "");
 
-        auto latestRuntimeRef = repo.remoteLatestRef(remoteRuntimeRef);
-        ret = repo.checkoutAll(latestRuntimeRef, "", targetPath);
+        auto result = repo.remoteLatestRef(remoteRuntimeRef);
+        ret = repo.checkoutAll(std::get<1>(result), "", targetPath);
         if (!ret.success()) {
             return NewError(-1, "checkout runtime files failed");
         }

--- a/src/module/repo/ostree_repo.h
+++ b/src/module/repo/ostree_repo.h
@@ -9,6 +9,7 @@
 
 #include "module/package/package.h"
 #include "module/repo/repo.h"
+#include "repo.h"
 
 #include <QPointer>
 #include <QScopedPointer>
@@ -87,7 +88,7 @@ public:
 
     package::Ref localLatestRef(const package::Ref &ref);
 
-    package::Ref remoteLatestRef(const package::Ref &ref);
+    std::tuple<util::Error, package::Ref> remoteLatestRef(const package::Ref &ref);
 
     package::Ref latestOfRef(const QString &appId, const QString &appVersion) override;
 


### PR DESCRIPTION
Try to make the promots more clearer when we pull some ref failed. We should return with error info in getLatestRemoteRef().

Log: