### PR TITLE
fix use correct config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,16 @@
 # SPDX-FileCopyrightText: None
-#
 # SPDX-License-Identifier: CC0-1.0
 
 /*build*
-.idea/
+/.idea/
+/debian/.debhelper
+/debian/debhelper-build-stamp
+/debian/files
+/debian/linglong-*
+/debian/linglong-bin.debhelper.log
+/debian/linglong-bin.substvars
+/debian/linglong-builder
+/debian/linglong-builder.debhelper.log
+/debian/linglong-builder.substvars
+/debian/tmp/usr
+/obj-x86_64-linux-gnu

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -819,7 +819,7 @@ int main(int argc, char **argv)
                   parser.addPositionalArgument("modify", "modify opretion of repo", "modify");
                   parser.addPositionalArgument("url", "the url of repo", "[url]");
 
-                  const auto optName = QCommandLineOption("name", "the name of repo", "repo name", "repo");
+                  const auto optName = QCommandLineOption("name", "the name of repo", "repo name", "deepin");
                   parser.addOption(optName);
                   parser.process(app);
 

--- a/debian/control
+++ b/debian/control
@@ -39,9 +39,10 @@ Architecture: any
 Depends:
  ${shlibs:Depends},
  ${misc:Depends},
- linglong-loader,
  linglong-bin,
  linglong-box,
  erofs-utils
+Recommends:
+ linglong-loader
 Description: Linglong application building tools.
  ll-builder is a tool that makes it easy to build applications and dependencies.

--- a/external/qserializer/CMakeLists.txt
+++ b/external/qserializer/CMakeLists.txt
@@ -8,7 +8,7 @@ project (
         LANGUAGES
                 CXX
         VERSION
-                0.1.1
+                0.3.0
 )
 
 include (${PROJECT_SOURCE_DIR}/misc/cmake/GetSemverFromGit.cmake)

--- a/external/qserializer/examples/dbus_message/api/dbus/io.github.black_desk.TestDBusServer.xml
+++ b/external/qserializer/examples/dbus_message/api/dbus/io.github.black_desk.TestDBusServer.xml
@@ -4,7 +4,7 @@
   <interface name='io.github.black_desk.TestDBusServer'>
     <method name='ping'>
       <annotation name='org.qtproject.QtDBus.QtTypeName.Out0'
-        value='QMap&lt;QString,QSharedPointer&lt;qserializer::examples::dbus_message::Response&gt;&gt;' />
+        value='QMap&lt;QString,QSharedPointer&lt;const qserializer::examples::dbus_message::Response&gt;&gt;' />
       <arg name='result' type='a{sa{sv}}' direction='out' />
     </method>
   </interface>

--- a/external/qserializer/examples/dbus_message/apps/server/src/qserializer/examples/dbus_message/Server.cpp
+++ b/external/qserializer/examples/dbus_message/apps/server/src/qserializer/examples/dbus_message/Server.cpp
@@ -20,7 +20,7 @@ Server::Server(QObject *parent)
 
 Server::~Server() = default;
 
-QMap<QString, QSharedPointer<Response>> Server::ping()
+QMap<QString, QSharedPointer<const Response>> Server::ping()
 {
         auto resp = QSharedPointer<Response>(new Response);
         resp->msg = "message";

--- a/external/qserializer/examples/dbus_message/apps/server/src/qserializer/examples/dbus_message/Server.h
+++ b/external/qserializer/examples/dbus_message/apps/server/src/qserializer/examples/dbus_message/Server.h
@@ -22,7 +22,7 @@ class Server : public QObject {
         Server(QObject *parent = nullptr);
         virtual ~Server();
     public slots:
-        QMap<QString, QSharedPointer<Response>> ping();
+        QMap<QString, QSharedPointer<const Response>> ping();
 };
 
 }

--- a/external/qserializer/libs/core/include/qserializer/core.h
+++ b/external/qserializer/libs/core/include/qserializer/core.h
@@ -6,9 +6,11 @@
 
 #if QT_VERSION <= QT_VERSION_CHECK(6, 2, 0)
 #define QSERIALIZER_DECLARE_SHAREDPOINTER_METATYPE(x) \
-        Q_DECLARE_METATYPE(QSharedPointer<x>);
+        Q_DECLARE_METATYPE(QSharedPointer<x>);        \
+        Q_DECLARE_METATYPE(QSharedPointer<const x>);
 #else
-#define QSERIALIZER_DECLARE_SHAREDPOINTER_METATYPE(x)
+#define QSERIALIZER_DECLARE_SHAREDPOINTER_METATYPE(x) \
+        Q_DECLARE_METATYPE(QSharedPointer<const x>);
 #endif
 
 // NOTE:
@@ -19,20 +21,21 @@
         QSERIALIZER_DECLARE_SHAREDPOINTER_METATYPE(T); \
         namespace qserializer::detail::init::T         \
         {                                              \
-        char init();                                   \
+        char init() noexcept;                          \
         static char _ = init();                        \
         };
 
-#define QSERIALIZER_IMPL(T, ...)                                \
-        namespace qserializer::detail::init::T                  \
-        {                                                       \
-        char init()                                             \
-        {                                                       \
-                static char _ = []() -> char {                  \
-                        QSerializer<::T>::registerConverters(); \
-                        __VA_ARGS__;                            \
-                        return 0;                               \
-                }();                                            \
-                return _;                                       \
-        }                                                       \
+#define QSERIALIZER_IMPL(T, ...)                                      \
+        namespace qserializer::detail::init::T                        \
+        {                                                             \
+        char init() noexcept                                          \
+        {                                                             \
+                static char _ = []() -> char {                        \
+                        QSerializer<::T>::registerConverters();       \
+                        QSerializer<const ::T>::registerConverters(); \
+                        __VA_ARGS__;                                  \
+                        return 0;                                     \
+                }();                                                  \
+                return _;                                             \
+        }                                                             \
         }

--- a/external/qserializer/libs/core/include/qserializer/detail/QSerializer.h
+++ b/external/qserializer/libs/core/include/qserializer/detail/QSerializer.h
@@ -38,15 +38,15 @@ class QSerializer {
     private:
         typedef QSharedPointer<T> P;
 
-        static QVariantMap PToQVariantMap(P from);
-        static P QVariantMapToP(const QVariantMap &map);
+        static QVariantMap PToQVariantMap(P from) noexcept;
+        static P QVariantMapToP(const QVariantMap &map) noexcept;
 
-        static QVariantList PListToQVariantList(QList<P> list);
+        static QVariantList PListToQVariantList(QList<P> list) noexcept;
 
-        static QList<P> QVariantListToPList(QVariantList list);
+        static QList<P> QVariantListToPList(QVariantList list) noexcept;
 
-        static QVariantMap PStrMapToQVariantMap(QMap<QString, P> map);
-        static QMap<QString, P> QVariantMapToPStrMap(QVariantMap map);
+        static QVariantMap PStrMapToQVariantMap(QMap<QString, P> map) noexcept;
+        static QMap<QString, P> QVariantMapToPStrMap(QVariantMap map) noexcept;
 };
 
 template <typename T>
@@ -57,17 +57,17 @@ void QSerializer<T>::registerConverters()
 
         QMetaType::registerConverter<QList<P>, QVariantList>(
                 PListToQVariantList);
-        QMetaType::registerConverter<QVariantList, QList<P> >(
+        QMetaType::registerConverter<QVariantList, QList<P>>(
                 QVariantListToPList);
 
         QMetaType::registerConverter<QMap<QString, P>, QVariantMap>(
                 PStrMapToQVariantMap);
-        QMetaType::registerConverter<QVariantMap, QMap<QString, P> >(
+        QMetaType::registerConverter<QVariantMap, QMap<QString, P>>(
                 QVariantMapToPStrMap);
 }
 
 template <typename T>
-QVariantMap QSerializer<T>::PToQVariantMap(P from)
+QVariantMap QSerializer<T>::PToQVariantMap(P from) noexcept
 {
         auto ret = QVariantMap{};
         if (from.isNull()) {
@@ -100,12 +100,14 @@ QVariantMap QSerializer<T>::PToQVariantMap(P from)
 }
 
 template <typename T>
-QSharedPointer<T> QSerializer<T>::QVariantMapToP(const QVariantMap &map)
+QSharedPointer<T>
+QSerializer<T>::QVariantMapToP(const QVariantMap &map) noexcept
 {
-        P ret(new T());
+        QSharedPointer<std::remove_const_t<T>> ret(
+                new std::remove_const_t<T>());
 
         static const QMetaObject *const metaObject =
-                QMetaType::fromType<T *>().metaObject();
+                QMetaType::fromType<std::remove_const_t<T> *>().metaObject();
 
         for (int i = 0; i < metaObject->propertyCount(); i++) {
                 QMetaProperty metaProp = metaObject->property(i);
@@ -129,7 +131,7 @@ QSharedPointer<T> QSerializer<T>::QVariantMapToP(const QVariantMap &map)
 }
 
 template <typename T>
-QVariantList QSerializer<T>::PListToQVariantList(QList<P> list)
+QVariantList QSerializer<T>::PListToQVariantList(QList<P> list) noexcept
 {
         auto ret = QVariantList{};
         for (auto const &item : list) {
@@ -139,7 +141,8 @@ QVariantList QSerializer<T>::PListToQVariantList(QList<P> list)
 }
 
 template <typename T>
-QList<QSharedPointer<T> > QSerializer<T>::QVariantListToPList(QVariantList list)
+QList<QSharedPointer<T>>
+QSerializer<T>::QVariantListToPList(QVariantList list) noexcept
 {
         auto ret = QList<P>{};
         for (auto const &item : list) {
@@ -149,7 +152,7 @@ QList<QSharedPointer<T> > QSerializer<T>::QVariantListToPList(QVariantList list)
 }
 
 template <typename T>
-QVariantMap QSerializer<T>::PStrMapToQVariantMap(QMap<QString, P> map)
+QVariantMap QSerializer<T>::PStrMapToQVariantMap(QMap<QString, P> map) noexcept
 {
         auto ret = QVariantMap{};
         for (auto it = map.begin(); it != map.end(); it++) {
@@ -159,8 +162,8 @@ QVariantMap QSerializer<T>::PStrMapToQVariantMap(QMap<QString, P> map)
 }
 
 template <typename T>
-QMap<QString, QSharedPointer<T> >
-QSerializer<T>::QVariantMapToPStrMap(QVariantMap map)
+QMap<QString, QSharedPointer<T>>
+QSerializer<T>::QVariantMapToPStrMap(QVariantMap map) noexcept
 {
         auto ret = QMap<QString, P>{};
         for (auto it = map.begin(); it != map.end(); it++) {
@@ -168,4 +171,5 @@ QSerializer<T>::QVariantMapToPStrMap(QVariantMap map)
         }
         return ret;
 }
+
 }

--- a/external/qserializer/libs/dbus/include/qserializer/dbus.h
+++ b/external/qserializer/libs/dbus/include/qserializer/dbus.h
@@ -10,11 +10,23 @@
                 return qserializer::detail::dbus::move_in<QSharedPointer<T>>(  \
                         args, x);                                              \
         }                                                                      \
+        [[maybe_unused]] inline const QDBusArgument &operator<<(               \
+                QDBusArgument &args, const QSharedPointer<const T> &x)         \
+        {                                                                      \
+                return qserializer::detail::dbus::move_in<                     \
+                        QSharedPointer<const T>>(args, x);                     \
+        }                                                                      \
         [[maybe_unused]] inline const QDBusArgument &operator>>(               \
                 const QDBusArgument &args, QSharedPointer<T> &x)               \
         {                                                                      \
                 return qserializer::detail::dbus::move_out<QSharedPointer<T>>( \
                         args, x);                                              \
+        }                                                                      \
+        [[maybe_unused]] inline const QDBusArgument &operator>>(               \
+                const QDBusArgument &args, QSharedPointer<const T> &x)         \
+        {                                                                      \
+                return qserializer::detail::dbus::move_out<                    \
+                        QSharedPointer<const T>>(args, x);                     \
         }
 
 // NOTE:
@@ -27,6 +39,10 @@
 #define QSERIALIZER_IMPL_DBUS(T, ...)                                        \
         QSERIALIZER_IMPL(T, {                                                \
                 qDBusRegisterMetaType<QSharedPointer<::T>>();                \
+                qDBusRegisterMetaType<QSharedPointer<const ::T>>();          \
                 qDBusRegisterMetaType<QList<QSharedPointer<::T>>>();         \
+                qDBusRegisterMetaType<QList<QSharedPointer<const ::T>>>();   \
                 qDBusRegisterMetaType<QMap<QString, QSharedPointer<::T>>>(); \
+                qDBusRegisterMetaType<                                       \
+                        QMap<QString, QSharedPointer<const ::T>>>();         \
         } __VA_OPT__(, ) __VA_ARGS__)

--- a/external/qserializer/tests/src/qserializer/test_types/Book.h
+++ b/external/qserializer/tests/src/qserializer/test_types/Book.h
@@ -26,8 +26,8 @@ class Book : public Base {
         // NOTE:
         // Qt5 can not found convertor
         // if type referenced in Q_PROPERTY is not global.
-        Q_PROPERTY(QList<QSharedPointer<qserializer::test_types::Page> > pages
-                           MEMBER m_pages);
+        Q_PROPERTY(QList<QSharedPointer<const qserializer::test_types::Page> >
+                           pages MEMBER m_pages);
         Q_PROPERTY(QMap<QString, QSharedPointer<qserializer::test_types::Page> >
                            dict MEMBER m_dict);
         Q_PROPERTY(QStringList list MEMBER m_list1);
@@ -37,7 +37,7 @@ class Book : public Base {
 
     public:
         QString m_title;
-        QList<QSharedPointer<Page> > m_pages;
+        QList<QSharedPointer<const Page> > m_pages;
         QMap<QString, QSharedPointer<Page> > m_dict;
         QStringList m_list1;
         // NOTE:

--- a/src/linglong/package_manager/package_manager.cpp
+++ b/src/linglong/package_manager/package_manager.cpp
@@ -45,8 +45,8 @@ PackageManagerPrivate::PackageManagerPrivate(PackageManager *parent)
                   }
                   return QDBusConnection::systemBus();
               }())
-    , repoClient(ConfigInstance().repos[package::kDefaultRepo]->endpoint)
-    , remoteRepoName(ConfigInstance().repos[package::kDefaultRepo]->repoName)
+    , repoClient(util::config::ConfigInstance().repos[package::kDefaultRepo]->endpoint)
+    , remoteRepoName(util::config::ConfigInstance().repos[package::kDefaultRepo]->repoName)
     , q_ptr(parent)
 {
 }
@@ -1357,7 +1357,7 @@ QueryReply PackageManager::getRepoInfo()
         reply.code = STATUS_CODE(kFail);
         return reply;
     }
-    
+
     QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
     QJsonObject infoObj = doc.object();
 
@@ -1386,15 +1386,15 @@ Reply PackageManager::ModifyRepo(const QString &name, const QString &url)
     }
 
     // update config yaml
-    if (!ConfigInstance().repos.contains(name)) {
+    if (!util::config::ConfigInstance().repos.contains(name)) {
         reply.message = name + " not exist";
         qWarning() << reply.message;
         reply.code = STATUS_CODE(kUserInputParamErr);
         return reply;
     }
 
-    ConfigInstance().repos[name]->endpoint = url;
-    ConfigInstance().save();
+    util::config::ConfigInstance().repos[name]->endpoint = url;
+    util::config::ConfigInstance().save();
 
     bool ret = OSTREE_REPO_HELPER->ensureRepoEnv(d->kLocalRepoPath, reply.message);
     if (!ret) {

--- a/src/linglong/package_manager/package_manager.cpp
+++ b/src/linglong/package_manager/package_manager.cpp
@@ -1348,24 +1348,13 @@ PackageManager::~PackageManager() { }
 QueryReply PackageManager::getRepoInfo()
 {
     QueryReply reply;
-    Q_D(PackageManager);
-    auto serverCfg = d->kLocalRepoPath + "/config.json";
+    const auto &config = util::config::ConfigInstance();
 
-    QFile file(serverCfg);
-    if (!file.open(QIODevice::ReadOnly)) {
-        reply.message = serverCfg + " no exist";
-        reply.code = STATUS_CODE(kFail);
-        return reply;
-    }
-
-    QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
-    QJsonObject infoObj = doc.object();
-
+    // FIXME(black_desk):
+    // This is a workaround, we may have multiple repositories.
     reply.code = STATUS_CODE(kSuccess);
-    reply.message = infoObj["repoName"].toString();
-    reply.result = infoObj["appDbUrl"].toString();
-
-    file.close();
+    reply.message = config.repos.firstKey();
+    reply.result = config.repos.first()->endpoint;
 
     return reply;
 }

--- a/src/linglong/repo/ostree_repohelper.cpp
+++ b/src/linglong/repo/ostree_repohelper.cpp
@@ -100,8 +100,8 @@ bool OstreeRepoHelper::ensureRepoEnv(const QString &repoDir, QString &err)
         return false;
     }
 
-    QString url = ConfigInstance().repos[package::kDefaultRepo]->endpoint;
-    QString repoName = ConfigInstance().repos[package::kDefaultRepo]->repoName;
+    QString url = util::config::ConfigInstance().repos[package::kDefaultRepo]->endpoint;
+    QString repoName = util::config::ConfigInstance().repos[package::kDefaultRepo]->repoName;
 
     url += "/repos/" + repoName;
 

--- a/src/linglong/repo/repo_client.cpp
+++ b/src/linglong/repo/repo_client.cpp
@@ -8,6 +8,7 @@
 
 #include "linglong/package/package.h"
 #include "linglong/util/config/config.h"
+#include "linglong/util/file.h"
 #include "linglong/util/http/http_client.h"
 #include "linglong/util/qserializer/deprecated.h"
 

--- a/src/linglong/repo/repo_client.cpp
+++ b/src/linglong/repo/repo_client.cpp
@@ -105,5 +105,10 @@ RepoClient::RepoClient(const QString &endpoint)
 {
 }
 
+void RepoClient::setEndpoint(const QString &endpoint)
+{
+    this->endpoint = endpoint;
+}
+
 } // namespace repo
 } // namespace linglong

--- a/src/linglong/repo/repo_client.h
+++ b/src/linglong/repo/repo_client.h
@@ -51,6 +51,14 @@ class RepoClient
 public:
     explicit RepoClient(const QString &endpoint);
 
+    // FIXME(black_desk):
+    // This method is just a workaround used to
+    // update RepoClient::endpoint
+    // when endpoint get updated
+    // by PackageManager::RepoModify.
+    // It's not thread-safe.
+    void setEndpoint(const QString &endpoint);
+
     std::tuple<util::Error, QList<QSharedPointer<package::AppMetaInfo>>>
     QueryApps(const package::Ref &ref);
 

--- a/src/linglong/util/config/CMakeLists.txt
+++ b/src/linglong/util/config/CMakeLists.txt
@@ -6,8 +6,10 @@ linglong_add_library(
   config
   SOURCES
   config.cpp
+  repo.cpp
   HEADERS
   config.h
+  repo.h
   DEPENDENCIES
   Qt::Core
   linglong_util_qserializer

--- a/src/linglong/util/config/config.cpp
+++ b/src/linglong/util/config/config.cpp
@@ -10,7 +10,7 @@
 #include "linglong/util/file.h"
 #include "linglong/util/qserializer/yaml.h"
 
-namespace linglong::config {
+namespace linglong::util::config {
 
 QSERIALIZER_IMPL(Repo)
 QSERIALIZER_IMPL(Config)
@@ -19,11 +19,11 @@ static const char *const kConfigFileName = "config.yaml";
 
 QSharedPointer<Config> loadConfig()
 {
-    auto configFilePath = util::findLinglongConfigPath(kConfigFileName, false);
+    auto configFilePath = findLinglongConfigPath(kConfigFileName, false);
     qDebug() << "load" << configFilePath;
     QSharedPointer<Config> config;
     try {
-        config = std::get<0>(linglong::util::fromYAML<QSharedPointer<Config>>(configFilePath));
+        config = std::get<0>(fromYAML<QSharedPointer<Config>>(configFilePath));
     } catch (...) {
         qWarning() << "Failed to load config, cfg:" << config;
     }
@@ -43,7 +43,7 @@ QSharedPointer<Config> loadConfig()
     Q_ASSERT(config->repos.contains(package::kDefaultRepo));
 
     config->self = config;
-    config->path = util::findLinglongConfigPath(kConfigFileName, true);
+    config->path = findLinglongConfigPath(kConfigFileName, true);
     return config;
 }
 
@@ -52,7 +52,7 @@ QSharedPointer<Config> loadConfig()
  */
 void Config::save()
 {
-    auto [data, err] = util::toYAML(this->self.toStrongRef());
+    auto [data, err] = toYAML(this->self.toStrongRef());
     if (err) {
         qCritical() << "convert to yaml failed with" << err;
         return;
@@ -74,4 +74,4 @@ Config &ConfigInstance()
     return *config;
 }
 
-} // namespace linglong::config
+} // namespace linglong::util::config

--- a/src/linglong/util/config/config.cpp
+++ b/src/linglong/util/config/config.cpp
@@ -17,29 +17,27 @@ QSERIALIZER_IMPL(Config)
 
 static const char *const kConfigFileName = "config.yaml";
 
-QSharedPointer<config::Config> loadConfig()
+QSharedPointer<Config> loadConfig()
 {
     auto configFilePath = util::findLinglongConfigPath(kConfigFileName, false);
     qDebug() << "load" << configFilePath;
-    QSharedPointer<config::Config> config;
+    QSharedPointer<Config> config;
     try {
-        config = std::get<0>(
-                linglong::util::fromYAML<QSharedPointer<config::Config>>(configFilePath));
+        config = std::get<0>(linglong::util::fromYAML<QSharedPointer<Config>>(configFilePath));
     } catch (...) {
         qWarning() << "Failed to load config, cfg:" << config;
     }
 
     if (!config) {
         qWarning() << "load config failed";
-        config = QSharedPointer<config::Config>(new Config());
+        config = QSharedPointer<Config>(new Config());
     }
 
     Q_ASSERT(config);
 
     if (!config->repos.contains(package::kDefaultRepo)) {
         qWarning() << "load config for" << package::kDefaultRepo << "failed";
-        config->repos.insert(package::kDefaultRepo,
-                             QSharedPointer<config::Repo>(new Repo(config.data())));
+        config->repos.insert(package::kDefaultRepo, QSharedPointer<Repo>(new Repo(config.data())));
     }
 
     Q_ASSERT(config->repos.contains(package::kDefaultRepo));

--- a/src/linglong/util/config/config.cpp
+++ b/src/linglong/util/config/config.cpp
@@ -70,10 +70,10 @@ void Config::save()
     configFile.close();
 }
 
-} // namespace linglong
-
-linglong::config::Config &ConfigInstance()
+Config &ConfigInstance()
 {
-    static QSharedPointer<linglong::config::Config> config(linglong::config::loadConfig());
+    static QSharedPointer<Config> config(loadConfig());
     return *config;
 }
+
+} // namespace linglong::config

--- a/src/linglong/util/config/config.cpp
+++ b/src/linglong/util/config/config.cpp
@@ -12,7 +12,6 @@
 
 namespace linglong::util::config {
 
-QSERIALIZER_IMPL(Repo)
 QSERIALIZER_IMPL(Config)
 
 static const char *const kConfigFileName = "config.yaml";

--- a/src/linglong/util/config/config.h
+++ b/src/linglong/util/config/config.h
@@ -11,7 +11,7 @@
 
 #include "linglong/util/qserializer/deprecated.h"
 
-namespace linglong::config {
+namespace linglong::util::config {
 
 class Repo : public Serialize
 {
@@ -28,7 +28,7 @@ class Config : public Serialize
     Q_SERIALIZE_CONSTRUCTOR(Config)
 
 public:
-    Q_PROPERTY(QMap<QString, QSharedPointer<linglong::config::Repo>> repos MEMBER repos);
+    Q_PROPERTY(QMap<QString, QSharedPointer<linglong::util::config::Repo>> repos MEMBER repos);
     QMap<QString, QSharedPointer<Repo>> repos;
 
 public:
@@ -47,6 +47,6 @@ QSERIALIZER_DECLARE(Config)
 
 Config &ConfigInstance();
 
-} // namespace linglong::config
+} // namespace linglong::util::config
 
 #endif // LINGLONG_SRC_MODULE_UTIL_CONFIG_CONFIG_H_

--- a/src/linglong/util/config/config.h
+++ b/src/linglong/util/config/config.h
@@ -48,9 +48,8 @@ private:
 QSERIALIZER_DECLARE(Repo)
 QSERIALIZER_DECLARE(Config)
 
-} // namespace linglong
+Config &ConfigInstance();
 
-linglong::config::Config &ConfigInstance();
-
+} // namespace linglong::config
 
 #endif // LINGLONG_SRC_MODULE_UTIL_CONFIG_CONFIG_H_

--- a/src/linglong/util/config/config.h
+++ b/src/linglong/util/config/config.h
@@ -9,10 +9,7 @@
 
 // yaml/json format config
 
-#include "linglong/repo/repo.h"
-#include "linglong/util/file.h"
 #include "linglong/util/qserializer/deprecated.h"
-#include "linglong/util/qserializer/json.h"
 
 namespace linglong::config {
 

--- a/src/linglong/util/config/config.h
+++ b/src/linglong/util/config/config.h
@@ -29,13 +29,13 @@ class Config : public Serialize
 
 public:
     Q_PROPERTY(QMap<QString, QSharedPointer<linglong::config::Repo>> repos MEMBER repos);
-    QMap<QString, QSharedPointer<config::Repo>> repos;
+    QMap<QString, QSharedPointer<Repo>> repos;
 
 public:
     void save();
 
 private:
-    friend QSharedPointer<config::Config> loadConfig();
+    friend QSharedPointer<Config> loadConfig();
     QString path;
 
     // TODO: it so strange that a global config could not serialize self

--- a/src/linglong/util/config/config.h
+++ b/src/linglong/util/config/config.h
@@ -9,23 +9,15 @@
 
 // yaml/json format config
 
+#include "linglong/util/config/repo.h"
 #include "linglong/util/qserializer/deprecated.h"
 
 namespace linglong::util::config {
 
-class Repo : public Serialize
-{
-    Q_OBJECT;
-    Q_SERIALIZE_CONSTRUCTOR(Repo)
-public:
-    Q_SERIALIZE_PROPERTY(QString, endpoint);
-    Q_SERIALIZE_PROPERTY(QString, repoName);
-};
-
 class Config : public Serialize
 {
     Q_OBJECT;
-    Q_SERIALIZE_CONSTRUCTOR(Config)
+    Q_SERIALIZE_CONSTRUCTOR(Config);
 
 public:
     Q_PROPERTY(QMap<QString, QSharedPointer<linglong::util::config::Repo>> repos MEMBER repos);
@@ -42,8 +34,7 @@ private:
     QWeakPointer<Config> self;
 };
 
-QSERIALIZER_DECLARE(Repo)
-QSERIALIZER_DECLARE(Config)
+QSERIALIZER_DECLARE(Config);
 
 Config &ConfigInstance();
 

--- a/src/linglong/util/config/config.h
+++ b/src/linglong/util/config/config.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-#ifndef LINGLONG_SRC_MODULE_UTIL_CONFIG_CONFIG_H_
-#define LINGLONG_SRC_MODULE_UTIL_CONFIG_CONFIG_H_
+#ifndef LINGLONG_UTIL_CONFIG_CONFIG_H_
+#define LINGLONG_UTIL_CONFIG_CONFIG_H_
 
 // yaml/json format config
 

--- a/src/linglong/util/config/repo.cpp
+++ b/src/linglong/util/config/repo.cpp
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include "linglong/util/config/repo.h"
+
+
+namespace linglong::util::config {
+
+QSERIALIZER_IMPL(Repo);
+
+}

--- a/src/linglong/util/config/repo.h
+++ b/src/linglong/util/config/repo.h
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#ifndef LINGLONG_UTIL_CONFIG_REPO_H_
+#define LINGLONG_UTIL_CONFIG_REPO_H_
+
+#include "linglong/util/qserializer/deprecated.h"
+
+namespace linglong::util::config {
+
+class Repo : public Serialize
+{
+    Q_OBJECT;
+    Q_SERIALIZE_CONSTRUCTOR(Repo);
+public:
+    Q_SERIALIZE_PROPERTY(QString, endpoint);
+    Q_SERIALIZE_PROPERTY(QString, repoName);
+};
+
+QSERIALIZER_DECLARE(Repo);
+
+} // namespace linglong::util::config
+#endif

--- a/src/linglong/util/file.cpp
+++ b/src/linglong/util/file.cpp
@@ -137,22 +137,20 @@ QString fileHash(const QString &path, QCryptographicHash::Algorithm method)
 
 QString findLinglongConfigPath(const QString &subpath, bool writeable)
 {
-    auto configDirs = QMap<QString, bool>{
-        { getLinglongRootPath(), true }, // /var/lib/linglong as distribution, should be writeable by linglong user
-        { LINGLONG_DATA_DIR, false },    // /usr/share/linglong as default
-    };
+    auto writeablePath = QDir(getLinglongRootPath()).absoluteFilePath(subpath);
+    auto paths = QList{ writeablePath, QDir(LINGLONG_DATA_DIR).absoluteFilePath(subpath) };
 
-    QMapIterator<QString, bool> iter(configDirs);
-    while (iter.hasNext()) {
-        iter.next();
-        QDir dir(iter.key());
-        if (writeable != iter.value()) {
+    if (writeable) {
+        return writeablePath;
+    }
+
+    for (const auto &path : paths) {
+        if (!QFile(path).exists()) {
             continue;
         }
-        if (writeable || dir.exists(subpath)) {
-            return dir.absoluteFilePath(subpath);
-        }
+        return path;
     }
+
     return "";
 }
 


### PR DESCRIPTION
- chore: update .gitignore
- refact: move ConfigInstance into namespace
- refact: rename protect marco
- refact: remove unused headers
- refact: remove unnecessary namespace
- refact: move linglong::{,util::}config
- refact: move linglong::config::Repo into single file
- chore: update qserializer to 0.3.0
- chore(debian): adjust depends
- fix(cli): correct the default repo name
- fix(pm): use ConfigInstance in getRepoInfo
- fix(pm): update repo::RepoClient::endpoint
- fix: correct findLinglongConfigPath
