### PR TITLE
fix: do not create "dbusProxyInfo" if not enable

### DIFF
--- a/src/linglong/runtime/app.cpp
+++ b/src/linglong/runtime/app.cpp
@@ -560,12 +560,13 @@ auto App::stageHost() -> int
 
 void App::stateDBusProxyArgs(bool enable, const QString &appId, const QString &proxyPath)
 {
-    auto &anno = *r.annotations;
-    anno["dbusProxyInfo"]["appId"] = appId.toStdString();
-    anno["dbusProxyInfo"]["enable"] = enable;
     if (!enable) {
         return;
     }
+
+    auto &anno = *r.annotations;
+    anno["dbusProxyInfo"]["enable"] = enable;
+    anno["dbusProxyInfo"]["appId"] = appId.toStdString();
     anno["dbusProxyInfo"]["busType"] = runParamMap[linglong::util::kKeyBusType].toStdString();
     anno["dbusProxyInfo"]["proxyPath"] = proxyPath.toStdString();
     // FIX to do load filter from yaml


### PR DESCRIPTION
After using ocppi, annotation is default to empty.

Old logical return after set "enable" to false
cause this object exists by not competed,
which leads to a ll-box crash.
