### PR TITLE
refactor: use systemd to start AppManager

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -9,7 +9,7 @@ Copyright: None
 License: CC0-1.0
 
 # Packaging configuration
-Files: rpm/* debian/* archlinux/* src/cli/misc/bash_completion/ll-cli src/cli/misc/bash_completion/llpkg src/service/misc/xdg/* src/package_manager/misc/* src/system_helper/misc/*
+Files: rpm/* debian/* archlinux/* src/cli/misc/bash_completion/ll-cli src/cli/misc/bash_completion/llpkg src/service/misc/xdg/* src/package_manager/misc/* src/system_helper/misc/* misc/dbus/* misc/systemd/service/* misc/systemd/user/*
 Copyright: None
 License: CC0-1.0
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linglong (1.3.16-1) unstable; urgency=medium
+
+  * use systemd to start AppManager
+
+ -- linxin <linxin@deepin.org>  Thu, 02 Nov 2023 14:52:47 +0800
+
 linglong (1.3.15-1) unstable; urgency=medium
 
   * Support git pull submodules.

--- a/debian/linglong-bin.install
+++ b/debian/linglong-bin.install
@@ -15,7 +15,9 @@ usr/share/dbus-1/system.d/org.deepin.linglong.PackageManager.conf
 usr/share/dbus-1/system-services/org.deepin.linglong.PackageManager.service
 usr/share/dbus-1/system.d/org.deepin.linglong.SystemHelper.conf
 usr/share/dbus-1/system-services/org.deepin.linglong.SystemHelper.service
+usr/share/dbus-1/services/org.deepin.linglong.AppManager.service
 lib/systemd/system/org.deepin.linglong.PackageManager.service
+usr/lib/systemd/user/org.deepin.linglong.AppManager.service
 lib/systemd/system/org.deepin.linglong.SystemHelper.service
 usr/share/mime/packages/deepin-linglong.xml
 

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -8,13 +8,26 @@ configure_file(
   @ONLY
 )
 
+configure_file(
+  dbus/org.deepin.linglong.AppManager.service.in
+  dbus/org.deepin.linglong.AppManager.service
+)
+
 set(SYSTEMD_USER_FILE
     ${CMAKE_CURRENT_BINARY_DIR}/systemd/user/linglong-upgrade.service
     systemd/user/linglong-upgrade.timer
 )
 
+set(DBUS_SESSION_SERVICE_FILE
+    ${CMAKE_CURRENT_BINARY_DIR}/dbus/org.deepin.linglong.AppManager.service
+)
+
 install(FILES ${SYSTEMD_USER_FILE}
         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/user/
+)
+
+install(FILES ${DBUS_SESSION_SERVICE_FILE}
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/services
 )
 
 configure_file(
@@ -27,4 +40,18 @@ set(LINGLONG_SCRIPTS ${CMAKE_CURRENT_BINARY_DIR}/scripts/upgrade-all)
 
 install(PROGRAMS ${LINGLONG_SCRIPTS}
         DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/linglong/
+)
+
+#systemd 
+configure_file(
+  systemd/service/org.deepin.linglong.AppManager.service.in
+  systemd/service/org.deepin.linglong.AppManager.service
+)
+
+set(SYSTEMD_USER_SERVICE_FILE
+    ${CMAKE_CURRENT_BINARY_DIR}/systemd/service/org.deepin.linglong.AppManager.service
+)
+
+install(FILES ${SYSTEMD_USER_SERVICE_FILE}
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/user/
 )

--- a/misc/dbus/org.deepin.linglong.AppManager.service.in
+++ b/misc/dbus/org.deepin.linglong.AppManager.service.in
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=org.deepin.linglong.AppManager
+Exec=@CMAKE_INSTALL_FULL_BINDIR@/ll-service
+SystemdService=org.deepin.linglong.AppManager.service

--- a/misc/systemd/service/org.deepin.linglong.AppManager.service.in
+++ b/misc/systemd/service/org.deepin.linglong.AppManager.service.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=Linglong AppManager service
+
+[Service]
+Type=dbus
+BusName=org.deepin.linglong.AppManager
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/ll-service
+Restart=on-failure
+RestartSec=10


### PR DESCRIPTION
We can use systemd to start AppManager.

This commit remove the old configure files of autostart AppManager.