### PR TITLE
fix: some app failed shared data by /tmp

### DIFF
--- a/src/module/runtime/app.cpp
+++ b/src/module/runtime/app.cpp
@@ -887,7 +887,9 @@ public:
         }
         QPointer<Mount> m(new Mount(r));
         m->type = "bind";
-        m->source = tmp.absolutePath();
+        // m->source = tmp.absolutePath();
+        // quickfix: mount host /tmp into container
+        m->source = tmpPath;
         m->destination = tmpPath;
         m->options = QStringList({ "rbind" });
         r->mounts.push_back(m);


### PR DESCRIPTION
Temporarily mount the host /tmp into the container
backport from dd39a06e03bd6d92e38b487d4a6016feaae9826a