### PR TITLE
fix: build failed in ostree_repo.cpp

### DIFF
--- a/src/linglong/repo/ostree_repo.h
+++ b/src/linglong/repo/ostree_repo.h
@@ -724,7 +724,7 @@ private:
 
     struct OstreeRepoDeleter
     {
-        static void operator()(OstreeRepo *repo)
+        void operator()(OstreeRepo *repo)
         {
             qDebug() << "delete OstreeRepo" << repo;
             g_clear_object(&repo);


### PR DESCRIPTION
Remove static from struct OstreeRepoDeleter.

Log: