### PR TITLE
fix: some app failed to use gsettings

### DIFF
--- a/src/linglong/utils/command/env.cpp
+++ b/src/linglong/utils/command/env.cpp
@@ -42,7 +42,8 @@ const QStringList envList = {
     "QT_WAYLAND_SHELL_INTEGRATION",
     "GDMSESSION",
     "QT_WAYLAND_FORCE_DPI",
-    "GIO_LAUNCHED_DESKTOP_FILE" // 系统监视器
+    "GIO_LAUNCHED_DESKTOP_FILE", // 系统监视器
+    "GNOME_DESKTOP_SESSION_ID" // gnome 桌面标识，有些应用会读取此变量以使用gsettings配置, 如chrome
 };
 
 QStringList getUserEnv(const QStringList &filters)


### PR DESCRIPTION
Add environment variable GNOME_DESKTOP_SESSION_ID into container, some applications rely on this variable to decide whether to use gsettings configuration. Such as chrome.

Log:"