### PR TITLE
fix: ref without channel

### DIFF
--- a/src/linglong/builder/linglong_builder.cpp
+++ b/src/linglong/builder/linglong_builder.cpp
@@ -1122,7 +1122,9 @@ linglong::util::Error LinglongBuilder::run()
         auto targetPath =
           BuilderConfig::instance()->layerPath({ project->ref().toLocalRefString() });
         linglong::util::ensureDir(targetPath);
-        auto ret = repo.checkoutAll(project->ref(), "", targetPath);
+        auto ref = project->ref();
+        ref.channel = "main";
+        auto ret = repo.checkoutAll(ref, "", targetPath);
         if (!ret.has_value()) {
             return NewError(-1, "checkout app files failed");
         }


### PR DESCRIPTION
can not checkout because of the argument ref without channel field