### PR TITLE
chore: repolaces and conflicts linglong-dbus-proxy

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,7 +35,7 @@ Depends: desktop-file-utils,
          erofsfuse,
          ${misc:Depends},
          ${shlibs:Depends}
-Recommends: linglong-dbus-proxy
+Conflicts: linglong-dbus-proxy
 Description: Linglong package manager.
  Linglong package management command line tool.
 


### PR DESCRIPTION
We don't use linglong-dbus-proxy form now.

Log: