### PR TITLE
feat: buildArch uses host arch by default

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -185,8 +185,6 @@ int main(int argc, char **argv)
                       return -1;
                   }
                   linglong::builder::BuilderConfig::instance()->setBuildArch((*arch).toString());
-              } else {
-                  linglong::builder::BuilderConfig::instance()->setBuildArch(linglong::util::hostArch());
               }
 
               // config linglong.yaml before build if necessary

--- a/src/linglong/builder/builder_config.cpp
+++ b/src/linglong/builder/builder_config.cpp
@@ -8,6 +8,7 @@
 
 #include "linglong/util/file.h"
 #include "linglong/util/qserializer/yaml.h"
+#include "linglong/util/sysinfo.h"
 #include "linglong/util/xdg.h"
 
 #include <mutex>
@@ -112,6 +113,9 @@ void BuilderConfig::setBuildArch(const QString &arch)
 
 QString BuilderConfig::getBuildArch() const
 {
+    if (buildArch.isEmpty()) {
+        return linglong::util::hostArch();
+    }
     return buildArch;
 }
 


### PR DESCRIPTION
buildArch默认使用主机的架构
修复builder run架构为空的问题

Log: