### PR TITLE
feat: mount rootfs using the 'squash_to_uid' args

### DIFF
--- a/src/linglong/runtime/app.h
+++ b/src/linglong/runtime/app.h
@@ -102,9 +102,10 @@ private:
 
     [[nodiscard]] auto stageSystem() -> int;
 
-    [[nodiscard]] auto stageRootfs(QString runtimeRootPath,
+    [[nodiscard]] auto stageRootfs(const QString &basePath,
+                                   const QString &runtimeRootPath,
                                    const QString &appId,
-                                   QString appRootPath) -> utils::error::Result<void>;
+                                   const QString &appRootPath) -> utils::error::Result<void>;
 
     [[nodiscard]] auto stageHost() -> int;
 


### PR DESCRIPTION
在运行应用时使用squash_to_uid参数挂载rootfs，避免权限问题

构建时因为应用文件存放在家目录,不会有权限问题,所以没加这个参数

Log: