### PR TITLE
feat: ll-builder add commit subcommand

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -292,6 +292,11 @@ int main(int argc, char **argv)
               }
               return 0;
           } },
+        { "commit",
+          [&](QCommandLineParser &parser) -> int {
+              builder.commit();
+              return 0;
+          } },
         { "run",
           [&](QCommandLineParser &parser) -> int {
               LINGLONG_TRACE("command run");

--- a/src/linglong/builder/linglong_builder.cpp
+++ b/src/linglong/builder/linglong_builder.cpp
@@ -1102,6 +1102,29 @@ linglong::utils::error::Result<void> LinglongBuilder::build()
     return LINGLONG_OK;
 }
 
+linglong::utils::error::Result<void> LinglongBuilder::commit()
+{
+    LINGLONG_TRACE("commit");
+    auto projectRet = buildStageProjectInit();
+    if (!projectRet) {
+        return LINGLONG_ERR(projectRet);
+    }
+    auto project = *projectRet;
+
+    QDir overlayDir(project->config().cacheAbsoluteFilePath({ "overlayfs" }));
+    auto overlayUpperDir = overlayDir.filePath("up/") + project->config().targetInstallPath("");
+    // overlayWorkDir 是overlay的内部工作目录
+    auto overlayWorkDir = overlayDir.filePath("wk");
+    auto overlayPointDir = overlayDir.filePath("point");
+
+    // 提交构建结果
+    auto voidRet = buildStageCommitBuildOutput(project.get(), overlayUpperDir, overlayPointDir);
+    if (!voidRet) {
+        return LINGLONG_ERR(voidRet);
+    }
+    return LINGLONG_OK;
+}
+
 linglong::util::Error LinglongBuilder::exportLayer(const QString &destination)
 {
     QDir destDir(destination);

--- a/src/linglong/builder/linglong_builder.h
+++ b/src/linglong/builder/linglong_builder.h
@@ -37,6 +37,8 @@ public:
 
     utils::error::Result<void> build() override;
 
+    utils::error::Result<void> commit();
+
     util::Error exportLayer(const QString &destination) override;
 
     util::Error extractLayer(const QString &layerPath, const QString &destination) override;


### PR DESCRIPTION
ll-builder添加commit子命令, 便于单独调试CommitBuildOutput方法
在build如果使用了skip-commit, 仍可使用commit提交当前的构建产物

Log: