### PR TITLE
fix: exec patch script timeout

### DIFF
--- a/src/linglong/runtime/container_builder.cpp
+++ b/src/linglong/runtime/container_builder.cpp
@@ -125,6 +125,7 @@ void applyExecutablePatch(ocppi::runtime::config::types::Config &cfg,
     generatorProcess.setProgram(info.absoluteFilePath());
     generatorProcess.start();
     generatorProcess.write(QByteArray::fromStdString(nlohmann::json(cfg).dump()));
+    generatorProcess.closeWriteChannel();
 
     constexpr auto timeout = 200;
     if (!generatorProcess.waitForFinished(timeout)) {


### PR DESCRIPTION
修复执行patch脚本超时的问题
应该在将数据写入到标准输入后,关闭写流程序才会退出

Log: