### PR TITLE
fix: missing XDG_RUNTIME_DIR environnent variable

### DIFF
--- a/src/linglong/utils/command/env.cpp
+++ b/src/linglong/utils/command/env.cpp
@@ -23,6 +23,7 @@ const QStringList envList = {
     "XDG_CURRENT_DESKTOP",
     "XIM",
     "XDG_SESSION_TYPE",
+    "XDG_RUNTIME_DIR",
     "CLUTTER_IM_MODULE",
     "QT4_IM_MODULE",
     "GTK_IM_MODULE",


### PR DESCRIPTION
容器环境缺少XDG_RUNTIME_DIR环境变量

Log: