### PR TITLE
fix: optimizing pull method

### DIFF
--- a/src/linglong/builder/linglong_builder.cpp
+++ b/src/linglong/builder/linglong_builder.cpp
@@ -128,7 +128,7 @@ utils::error::Result<package::Reference> pullDependency(QString fuzzyRefStr,
     QObject::connect(taskPtr.get(), &service::InstallTask::TaskChanged, taskChanged);
     repo.pull(taskPtr, *ref, develop);
     if (taskPtr->currentStatus() != service::InstallTask::Status::Success) {
-        return LINGLONG_ERR("pull " + ref->toString() + " failed");
+        return LINGLONG_ERR("pull " + ref->toString() + " failed", *taskPtr->currentError());
     }
 
     return *ref;

--- a/src/linglong/package_manager/task.cpp
+++ b/src/linglong/package_manager/task.cpp
@@ -4,6 +4,8 @@
 
 #include "task.h"
 
+#include "linglong/utils/error/error.h"
+
 #include <QDebug>
 #include <QUuid>
 
@@ -45,6 +47,21 @@ void InstallTask::updateStatus(Status newStatus, const QString &message) noexcep
 
     m_status = newStatus;
     Q_EMIT TaskChanged(taskID(), formatPercentage(), message, m_status, {});
+}
+
+void InstallTask::updateStatus(Status newStatus, linglong::utils::error::Result<void> err) noexcept
+{
+    qInfo() << "update task" << m_taskID << "status to" << newStatus << err.error().message();
+
+    if (newStatus == Success || newStatus == Failed || newStatus == Canceled) {
+        m_statePercentage = 100;
+    } else {
+        m_statePercentage += partsMap[m_status];
+    }
+
+    m_status = newStatus;
+    m_err.reset(&err);
+    Q_EMIT TaskChanged(taskID(), formatPercentage(), err.error().message(), m_status, {});
 }
 
 QString InstallTask::formatPercentage(double increase) const noexcept

--- a/src/linglong/package_manager/task.h
+++ b/src/linglong/package_manager/task.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "linglong/utils/error/error.h"
+
 #include <gio/gio.h>
 
 #include <QMap>
@@ -37,8 +39,11 @@ public:
                     double totalPercentage,
                     const QString &message = "") noexcept;
     void updateStatus(Status newStatus, const QString &message = "") noexcept;
+    void updateStatus(Status newStatus, linglong::utils::error::Result<void>) noexcept;
 
     [[nodiscard]] Status currentStatus() const noexcept { return m_status; }
+
+    [[nodiscard]] utils::error::Result<void> *currentError() const noexcept { return m_err.data(); }
 
     [[nodiscard]] QString taskID() const noexcept
     {
@@ -56,6 +61,7 @@ Q_SIGNALS:
 private:
     QString formatPercentage(double increase = 0) const noexcept;
     Status m_status{ Queued };
+    QSharedPointer<utils::error::Result<void>> m_err;
     double m_statePercentage{ 0 };
     QUuid m_taskID;
     GCancellable *m_cancelFlag{ nullptr };


### PR DESCRIPTION
将临时仓库放到.cache目录避免checkout时文件复制
在设置临时仓库的父仓库后,重新打开仓库使配置生效,避免增量更新无法使用

Log: