### PR TITLE
feat: ll-builder add the 'skip-pull-depend' param

### DIFF
--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -157,9 +157,11 @@ $defs:
         type: integer
       offline:
         type: boolean
-      skip_fetch:
+      skip_fetch_source:
         type: boolean
-      skip_commit:
+      skip_pull_depend:
+        type: boolean
+      skip_commit_output:
         type: boolean
       arch:
         type: string

--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -437,9 +437,14 @@ int main(int argc, char **argv)
               auto srcVersion =
                 QCommandLineOption("sversion", "set source version", "source version");
               auto srcCommit = QCommandLineOption("commit", "set commit refs", "source commit");
-              auto buildOffline = QCommandLineOption("offline", "only use local repo", "");
+              auto buildOffline = QCommandLineOption(
+                "offline",
+                "only use local files. This implies --skip-fetch-source and --skip-pull-depend",
+                "");
               auto buildSkipFetchSource =
-                QCommandLineOption("skip-fetch-source", "skip fetch source (build cache)", "");
+                QCommandLineOption("skip-fetch-source", "skip fetch sources", "");
+              auto buildSkipPullDepend =
+                QCommandLineOption("skip-pull-depend", "skip pull dependency", "");
               auto buildSkipCommitOutput =
                 QCommandLineOption("skip-commit-output", "skip commit build output", "");
               auto buildArch = QCommandLineOption("arch", "set the build arch", "arch");
@@ -450,6 +455,7 @@ int main(int argc, char **argv)
                                   srcCommit,
                                   buildOffline,
                                   buildSkipFetchSource,
+                                  buildSkipPullDepend,
                                   buildSkipCommitOutput,
                                   buildArch });
 
@@ -473,12 +479,24 @@ int main(int argc, char **argv)
               }
               if (parser.isSet(buildSkipFetchSource)) {
                   auto cfg = builder.getConfig();
-                  cfg.skipFetch = true;
+                  cfg.skipFetchSource = true;
+                  builder.setConfig(cfg);
+              }
+              if (parser.isSet(buildSkipPullDepend)) {
+                  auto cfg = builder.getConfig();
+                  cfg.skipPullDepend = true;
                   builder.setConfig(cfg);
               }
               if (parser.isSet(buildSkipCommitOutput)) {
                   auto cfg = builder.getConfig();
-                  cfg.skipCommit = true;
+                  cfg.skipCommitOutput = true;
+                  builder.setConfig(cfg);
+              }
+              if (parser.isSet(buildOffline)) {
+                  auto cfg = builder.getConfig();
+                  cfg.skipFetchSource = true;
+                  cfg.skipPullDepend = true;
+                  cfg.offline = true;
                   builder.setConfig(cfg);
               }
               auto allArgs = QCoreApplication::arguments();

--- a/src/linglong/api/types/v1/BuilderConfig.hpp
+++ b/src/linglong/api/types/v1/BuilderConfig.hpp
@@ -35,8 +35,9 @@ std::optional<std::string> arch;
 std::optional<std::string> cache;
 std::optional<bool> offline;
 std::string repo;
-std::optional<bool> skipCommit;
-std::optional<bool> skipFetch;
+std::optional<bool> skipCommitOutput;
+std::optional<bool> skipFetchSource;
+std::optional<bool> skipPullDepend;
 int64_t version;
 };
 }

--- a/src/linglong/api/types/v1/Generators.hpp
+++ b/src/linglong/api/types/v1/Generators.hpp
@@ -158,8 +158,9 @@ x.arch = get_stack_optional<std::string>(j, "arch");
 x.cache = get_stack_optional<std::string>(j, "cache");
 x.offline = get_stack_optional<bool>(j, "offline");
 x.repo = j.at("repo").get<std::string>();
-x.skipCommit = get_stack_optional<bool>(j, "skip_commit");
-x.skipFetch = get_stack_optional<bool>(j, "skip_fetch");
+x.skipCommitOutput = get_stack_optional<bool>(j, "skip_commit_output");
+x.skipFetchSource = get_stack_optional<bool>(j, "skip_fetch_source");
+x.skipPullDepend = get_stack_optional<bool>(j, "skip_pull_depend");
 x.version = j.at("version").get<int64_t>();
 }
 
@@ -175,11 +176,14 @@ if (x.offline) {
 j["offline"] = x.offline;
 }
 j["repo"] = x.repo;
-if (x.skipCommit) {
-j["skip_commit"] = x.skipCommit;
+if (x.skipCommitOutput) {
+j["skip_commit_output"] = x.skipCommitOutput;
 }
-if (x.skipFetch) {
-j["skip_fetch"] = x.skipFetch;
+if (x.skipFetchSource) {
+j["skip_fetch_source"] = x.skipFetchSource;
+}
+if (x.skipPullDepend) {
+j["skip_pull_depend"] = x.skipPullDepend;
 }
 j["version"] = x.version;
 }

--- a/src/linglong/runtime/container_builder.cpp
+++ b/src/linglong/runtime/container_builder.cpp
@@ -193,14 +193,11 @@ auto getOCIConfig(const ContainerOptions &opts) noexcept
     QString containerConfigFilePath = qgetenv("LINGLONG_CONTAINER_CONFIG");
     if (containerConfigFilePath.isEmpty()) {
         containerConfigFilePath = LINGLONG_INSTALL_PREFIX "/lib/linglong/container/config.json";
-        if (!utils::global::linglongInstalled() || !QFile(containerConfigFilePath).exists()) {
-            containerConfigFilePath = dir.filePath("config.json");
-            qWarning() << "Initializing the container using the embed config.json. "
-                + containerConfigFilePath;
-            QFile qrcFile(":/container/config.json");
-            if (!qrcFile.copy(containerConfigFilePath)) {
-                return LINGLONG_ERR(qrcFile);
-            };
+        if (!QFile(containerConfigFilePath).exists()) {
+            return LINGLONG_ERR(
+              QString("The container configuration file doesn't exist: %1\n"
+                      "You can specify a custom location using the LINGLONG_CONTAINER_CONFIG")
+                .arg(containerConfigFilePath));
         }
     }
 


### PR DESCRIPTION
build支持跳过拉取依赖的过程,便于在离线场景使用

Log: