### PR TITLE
feat: QDataStream should be used with LittleEndian

### DIFF
--- a/src/linglong/package/layer_file.cpp
+++ b/src/linglong/package/layer_file.cpp
@@ -76,7 +76,7 @@ utils::error::Result<quint32> LayerFile::metaInfoLength()
     QDataStream layerDataStream(this);
 
     layerDataStream.startTransaction();
-
+    layerDataStream.setByteOrder(QDataStream::LittleEndian);
     layerDataStream.skipRawData(magicNumber.size());
     quint32 metaInfoLength = 0;
     layerDataStream >> metaInfoLength;

--- a/src/linglong/package/layer_packager.cpp
+++ b/src/linglong/package/layer_packager.cpp
@@ -10,6 +10,7 @@
 #include "linglong/utils/command/env.h"
 
 #include <QDataStream>
+#include <QSysInfo>
 
 namespace linglong::package {
 
@@ -72,6 +73,7 @@ LayerPackager::pack(const LayerDir &dir, const QString &layerFilePath) const
 
     QDataStream dataSizeStream(&dataSizeBytes, QIODevice::WriteOnly);
     dataSizeStream.setVersion(QDataStream::Qt_5_10);
+    dataSizeStream.setByteOrder(QDataStream::LittleEndian);
     dataSizeStream << quint32(data.size());
 
     Q_ASSERT(dataSizeStream.status() == QDataStream::Status::Ok);


### PR DESCRIPTION
在导出Layer文件时, 应该强制使用小端编码, 避免兼容问题

Log: