### PR TITLE
fix: ll-builder run failed

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -804,7 +804,7 @@ utils::error::Result<void> Builder::run(const QStringList &args)
     if (!baseRef) {
         return LINGLONG_ERR(baseRef);
     }
-    auto baseDir = this->repo.getLayerDir(*baseRef, true);
+    auto baseDir = this->repo.getLayerDir(*baseRef, false);
     if (!baseDir) {
         return LINGLONG_ERR(baseDir);
     }


### PR DESCRIPTION
The default module of org.deepin.foundation should be runtime.

Log: