### PR TITLE
fix: kernel.unprivileged_userns_clone not set in uos v20

### DIFF
--- a/debian/linglong-bin.postinst
+++ b/debian/linglong-bin.postinst
@@ -48,6 +48,9 @@ upgrade_from_1_3_x() {
 case "$1" in
 configure)
         upgrade_from_1_3_x "$2"
+        if [ -f /etc/sysctl.d/linglong.conf ];then
+                sysctl -p /etc/sysctl.d/linglong.conf
+        fi
         ;;
 abort-upgrade | abort-remove | abort-deconfigure) ;;
 *)


### PR DESCRIPTION
linglong.conf should be reload after install

Log: