### PR TITLE
fix: the version of runtime is not fuzzy in info.json

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -641,8 +641,14 @@ utils::error::Result<void> Builder::build(const QStringList &args) noexcept
         }
     }
 
-    // Let base updated at runtime.
-    base->version.tweak = std::nullopt;
+    // when the base version is likes 20.0.0.1, warning that it is a full version
+    // if the base version is likes 20.0.0, we should also write 20.0.0 to info.json
+    if (fuzzyBase->version->tweak)
+    {
+        qWarning() << fuzzyBase->toString() << "is set a full version.";
+    } else {
+        base->version.tweak = std::nullopt;
+    }
 
     auto info = api::types::v1::PackageInfo{
         .appid = this->project.package.id,
@@ -661,6 +667,12 @@ utils::error::Result<void> Builder::build(const QStringList &args) noexcept
     };
 
     if (runtime) {
+        // the runtime version is same as base.
+        if (fuzzyRuntime->version->tweak) {
+            qWarning() << fuzzyRuntime->toString() << "is set a full version.";
+        } else {
+            runtime->version.tweak = std::nullopt;
+        }
         info.runtime = runtime->toString().toStdString();
     }
 


### PR DESCRIPTION
* Change the parameter of pullDependency from QString to FuzzyRefrence.
* If the version of base or runtime is not set tweak, we should not write the version with tweak to info.json.

Log: