### PR TITLE
fix: use host icon for linglong-repair-tool

### DIFF
--- a/misc/share/applications/linglong-repair-tool.desktop
+++ b/misc/share/applications/linglong-repair-tool.desktop
@@ -5,4 +5,5 @@ Name[zh_CN]=玲珑修复工具
 Type=Application
 TryExec=/var/lib/linglong/old-package.list
 Exec=deepin-terminal -C linglong-repair-tool
+Icon=deepin-repair-tools
 Categories=ConsoleOnly;System;


### PR DESCRIPTION
Using the icon 'deepin-repair-tools' which from deepin-icon-them.

Log: