### PR TITLE
fix(builder): --init-branch is not available in git 2.20.1

### DIFF
--- a/misc/libexec/linglong/fetch-git-repo
+++ b/misc/libexec/linglong/fetch-git-repo
@@ -17,7 +17,7 @@ cd "$workdir"
 if [ -d ".git" ]; then
     git remote set-url origin "$url"
 else
-    git init --initial-branch "$version"
+    git init
     git remote add origin "$url"
 fi
 


### PR DESCRIPTION
Signed-off-by: black-desk <me@black-desk.cn>
