### PR TITLE
fix(cmake): install linglong-repair-tool as a program

### DIFF
--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -140,7 +140,7 @@ install(
 
 # linglong-repair-tool bin
 install(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/script/linglong-repair-tool
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/script/linglong-repair-tool
   DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 


### PR DESCRIPTION
Previously, misc/CMakeLists.txt installed the program linglong-repair-tool as a "FILES" item (no executable bit), this is incorrect as the user would fail to run this program (with a "permission denied" error).

Correct the INSTALL() command and install linglong-repair-tool as a "PROGRAMS" item to give it executable bit at install-time.