### PR TITLE
fix: timezone is error for linglong app

### DIFF
--- a/apps/generators/90-legacy/src/main.cpp
+++ b/apps/generators/90-legacy/src/main.cpp
@@ -45,6 +45,7 @@ int main()
         { "/etc/resolv.conf", "/etc/resolv.conf" },
         { "/etc/resolvconf", "/etc/resolvconf" },
         { "/etc/localtime", "/etc/localtime" },
+        { "/etc/timezone ", "/etc/timezone" },
     };
 
     for (const auto &[source, destination] : roMountMap) {


### PR DESCRIPTION
mount /etc/timezone to container

Log: