### PR TITLE
Revert "fix: timezone is error for linglong app"

### DIFF
--- a/apps/generators/90-legacy/src/main.cpp
+++ b/apps/generators/90-legacy/src/main.cpp
@@ -45,7 +45,6 @@ int main()
         { "/etc/resolv.conf", "/etc/resolv.conf" },
         { "/etc/resolvconf", "/etc/resolvconf" },
         { "/etc/localtime", "/etc/localtime" },
-        { "/etc/timezone ", "/etc/timezone" },
     };
 
     for (const auto &[source, destination] : roMountMap) {


### PR DESCRIPTION
This reverts commit 69efe374c5aa8016eb0463706c9cbe0315e7f9b4.