### PR TITLE
fix: builder did not exit when the build script failed

### DIFF
--- a/libs/linglong/src/linglong/runtime/container.cpp
+++ b/libs/linglong/src/linglong/runtime/container.cpp
@@ -118,6 +118,7 @@ Container::run(const ocppi::runtime::config::types::Process &process) noexcept
         auto arguments = std::vector<std::string>{
             "/bin/bash",
             "--login",
+            "-e",
             "-c",
             bashArgs.join(" ").toStdString(),
         };


### PR DESCRIPTION
修复构建出错时, 玲珑没有正常的退出

Log: