### PR TITLE
fix: builder log redirection losing error message

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -127,8 +127,8 @@ int main(int argc, char **argv)
     // 初始化 qt qrc
     Q_INIT_RESOURCE(builder_releases);
     using namespace linglong::utils::global;
-
-    applicationInitializte();
+    // 初始化应用，builder在非tty环境也输出日志
+    applicationInitializte(true);
 
     auto ociRuntimeCLI = qgetenv("LINGLONG_OCI_RUNTIME");
     if (ociRuntimeCLI.isEmpty()) {

--- a/libs/linglong/src/linglong/utils/global/initialize.h
+++ b/libs/linglong/src/linglong/utils/global/initialize.h
@@ -9,7 +9,7 @@
 
 namespace linglong::utils::global {
 
-void applicationInitializte();
+void applicationInitializte(bool appForceStderrLogging = false);
 void installMessageHandler();
 bool linglongInstalled();
 


### PR DESCRIPTION
日志重定向会导致应用检测到非tty环境, 关闭stderr日志输出
builder强制开启非tty环境的终端日志输出

Log: