### PR TITLE
fix: missed some env variables when reusing container

### DIFF
--- a/apps/ll-box/src/main.cpp
+++ b/apps/ll-box/src/main.cpp
@@ -148,11 +148,8 @@ int exec(struct arg_exec *arg, int argc, char **argv) noexcept
     }
 
     auto wdns = linglong::util::format("--wdns=%s", arg->cwd.c_str());
-    const char *nsenterArgv[] = {
-        "nsenter", "-t",         boxPidStr.c_str(),        "-U",   "-m",
-        "-p",      wdns.c_str(), "--preserve-credentials", "bash", "--login",
-        "-c",      nullptr
-    };
+    const char *nsenterArgv[] = { "nsenter", "-t",         boxPidStr.c_str(),        "-U",   "-m",
+                                  "-p",      wdns.c_str(), "--preserve-credentials", nullptr };
 
     int nsenterArgc{ 0 };
     while (nsenterArgv[nsenterArgc] != nullptr) {
@@ -165,11 +162,9 @@ int exec(struct arg_exec *arg, int argc, char **argv) noexcept
         logErr() << "malloc error";
         return errno;
     }
-
     for (int i = 0; i < nsenterArgc; ++i) {
         newArgv[i] = nsenterArgv[i];
     }
-
     for (int i = 0; i < argc; ++i) {
         newArgv[i + nsenterArgc] = argv[i + 1];
     }

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -246,6 +246,24 @@ int Cli::run(std::map<std::string, docopt::value> &args)
             continue;
         }
 
+        QStringList bashArgs;
+        // 为避免原始args包含空格，每个arg都使用单引号包裹，并对arg内部的单引号进行转义替换
+        for (const auto &arg : execArgs) {
+            bashArgs.push_back(
+              QString("'%1'").arg(QString::fromStdString(arg).replace("'", "'\\''")));
+        }
+
+        if (!bashArgs.isEmpty()) {
+            // exec命令使用原始args中的进程替换bash进程
+            bashArgs.prepend("exec");
+        }
+        // 在原始args前面添加bash --login -c，这样可以使用/etc/profile配置的环境变量
+        execArgs = std::vector<std::string>{
+            "/bin/bash",
+            "--login",
+            "-c",
+            bashArgs.join(" ").toStdString(),
+        };
         auto result =
           this->ociCLI.exec(container.id,
                             execArgs[0],

--- a/libs/linglong/src/linglong/runtime/container.cpp
+++ b/libs/linglong/src/linglong/runtime/container.cpp
@@ -40,11 +40,10 @@ Container::run(const ocppi::runtime::config::types::Process &process) noexcept
     LINGLONG_TRACE(QString("run container %1").arg(this->id));
 
     QDir runtimeDir = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+
+    // bundle dir is already created in ContainerBuilder::create 
     QDir bundle = runtimeDir.absoluteFilePath(QString("linglong/%1").arg(this->id));
-    Q_ASSERT(!bundle.exists());
-    if (!bundle.mkpath(".")) {
-        return LINGLONG_ERR("make bundle directory");
-    }
+
     if (!bundle.mkpath("./rootfs")) {
         return LINGLONG_ERR("make rootfs directory");
     }


### PR DESCRIPTION
* Save env variables to /run/user/1000/linglong/$OCIRUNTIME/linglong99.sh and mount it to /etc/profile.d/linglong99.sh in container.
* Remove 'bash --login -c' from exec() of ll-box, we
      add it before create container.

Log: