### PR TITLE
fix: missed some env variables when reusing container

### DIFF
--- a/apps/ll-box/src/main.cpp
+++ b/apps/ll-box/src/main.cpp
@@ -158,7 +158,7 @@ int exec(struct arg_exec *arg, int argc, char **argv) noexcept
     while (nsenterArgv[nsenterArgc] != nullptr) {
         ++nsenterArgc;
     }
-    auto newArgc = nsenterArgc + argc + 1; // except argv[0] and add '&'
+    auto newArgc = nsenterArgc + 2; // add argvStr and add '&'
     const char **newArgv = (const char **)malloc(sizeof(char *) * newArgc);
 
     if (newArgv == nullptr) {
@@ -170,12 +170,22 @@ int exec(struct arg_exec *arg, int argc, char **argv) noexcept
         newArgv[i] = nsenterArgv[i];
     }
 
-    for (int i = 0; i < argc; ++i) {
-        newArgv[i + nsenterArgc] = argv[i + 1];
+    int argvStrLen = 2; // with two double quote
+    for (int i = 1; i < argc; ++i) {
+        argvStrLen += strlen(argv[i]) + 1; // each str with a blank
     }
 
-    newArgv[newArgc - 2] = "&";
-    newArgv[newArgc - 1] = nullptr;
+    char *argvStr = (char *)malloc(argvStrLen + 1);
+    strcpy(argvStr, "\"");
+    for (int i = 1; i < argc; i++) {
+        strcat(argvStr, argv[i]);
+        if (i < argc - 1) {
+            strcat(argvStr, " ");
+        }
+    }
+    strcat(argvStr, "\"");
+    newArgv[nsenterArgc] = argvStr;
+    newArgv[newArgc - 1] = "&";
 
     for (int i = 0; i < newArgc; ++i) {
         logDbg() << "newArgv[" << i << "]:" << newArgv[i];

--- a/libs/linglong/src/linglong/runtime/container.cpp
+++ b/libs/linglong/src/linglong/runtime/container.cpp
@@ -116,11 +116,7 @@ Container::run(const ocppi::runtime::config::types::Process &process) noexcept
         // quickfix: 某些应用在以bash -c启动后，收到SIGTERM后不会完全退出
         bashArgs.push_back("; wait");
         auto arguments = std::vector<std::string>{
-            "/bin/bash",
-            "--login",
-            "-e",
-            "-c",
-            bashArgs.join(" ").toStdString(),
+            "/bin/bash", "--login", "-e", "-c", bashArgs.join(" ").toStdString(),
         };
         this->cfg.process->args = arguments;
     }


### PR DESCRIPTION
* Save env variables to /run/user/1000/linglong/$OCIRUNTIME/linglong99.sh and mount it to /etc/profile.d/linglong99.sh in container.
* convert argv from "a" "b" "c" to "a b c".

Log: