### PR TITLE
refactor: using 'binary' as one of the module

### DIFF
--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -91,6 +91,7 @@ private:
     QDir repoDir;
     QDir ostreeRepoDir() const noexcept;
     QDir getLayerQDir(const package::Reference &ref, bool develop = false) const noexcept;
+    QDir getLayerQDirV2(const package::Reference &ref, bool develop = false) const noexcept;
 
     ClientFactory &m_clientFactory;
 };


### PR DESCRIPTION
    * Add ostreeSpecFromReferenceV2() which return
       a string with the 'binary' module.
    * Add getLayerQDirV2() which use ostreeSpecFromReferenceV2()
    * Always use 'binary' first and fallback to 'runtime'
Log: