### PR TITLE
fix: failed to run linglong app in ubuntu 24.04

### DIFF
--- a/debian/linglong-bin.postinst
+++ b/debian/linglong-bin.postinst
@@ -81,8 +81,9 @@ configure)
         version=$2
         shift
         # enable kernel.unprivileged_userns_clone
-        if [ -f /etc/sysctl.d/linglong.conf ];then
-                sysctl -p /etc/sysctl.d/linglong.conf
+        # disable kernel.apparmor_restrict_unprivileged_unconfined and kernel.apparmor_restrict_unprivileged_userns
+        if [ -f /usr/lib/sysctl.d/linglong.conf ];then
+                sysctl -p /usr/lib/sysctl.d/linglong.conf
         fi
         ;;
 abort-upgrade | abort-remove | abort-deconfigure) ;;

--- a/debian/rules
+++ b/debian/rules
@@ -8,12 +8,9 @@ VERSION=$(shell awk '/VERSION=/' /etc/os-release | sed 's/VERSION=//' | sed 's/\
 %:
 	dh $@ --buildsystem=cmake
 
-ifeq ($(OS) $(VERSION) $(ARCH), uos 20 amd)
 override_dh_auto_install:
 	dh_auto_install
-# linglong.conf will be installed to the first package in control file
-	dh_install debian/sysctl.d/linglong.conf /etc/sysctl.d
-endif
+	dh_install debian/sysctl.d/linglong.conf /usr/lib/sysctl.d/
 
 EXTRA_OPTION = -DCPM_LOCAL_PACKAGES_ONLY=ON -DLINGLONG_VERSION=$(DEB_VERSION_UPSTREAM)
 

--- a/debian/sysctl.d/linglong.conf
+++ b/debian/sysctl.d/linglong.conf
@@ -1,2 +1,6 @@
 # linglong app runs in a container, need privileges within user namespace, so we need to set it
 kernel.unprivileged_userns_clone=1
+# Ubuntu 24.04 has more limitation on unprivileged user namespace,so we have to disable them.
+# refer to https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
+kernel.apparmor_restrict_unprivileged_unconfined=0
+kernel.apparmor_restrict_unprivileged_userns=0


### PR DESCRIPTION
ubuntu 24.04 has more limitation on unprivileged user namespace,so we have to disable them

Log: