### PR TITLE
fix: layer size error when export layer repeatedly

### DIFF
--- a/libs/linglong/src/linglong/package/layer_packager.cpp
+++ b/libs/linglong/src/linglong/package/layer_packager.cpp
@@ -53,6 +53,10 @@ LayerPackager::pack(const LayerDir &dir, const QString &layerFilePath) const
     LINGLONG_TRACE("pack layer");
 
     QFile layer(layerFilePath);
+    if (layer.exists()) {
+        layer.remove();
+    }
+
     if (!layer.open(QIODevice::WriteOnly | QIODevice::Append)) {
         return LINGLONG_ERR(layer);
     }


### PR DESCRIPTION
if layer file exist, we must remove it before export it, or layer will overlay

Log:
Resolve: https://github.com/linuxdeepin/developer-center/issues/9033