### PR TITLE
fix: fix a warning during build deb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if(NOT ("${LINGLONG_VERSION}" STREQUAL ""))
   set(PROJECT_VERSION ${LINGLONG_VERSION})
 endif()
 
-set(ENABLE_UAB_HEADER OFF CACHE BOOL "enable building uab-header")
+set(ENABLE_UAB OFF CACHE BOOL "enable building UAB")
 
 set(LINGLONG_USERNAME
     "deepin-linglong"

--- a/apps/uab/CMakeLists.txt
+++ b/apps/uab/CMakeLists.txt
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-add_subdirectory(loader)
-
-if (NOT ${ENABLE_UAB_HEADER})
+if (NOT ${ENABLE_UAB})
     return()
 endif()
 
+add_subdirectory(loader)
 add_subdirectory(header)

--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,7 @@ override_dh_auto_install:
 EXTRA_OPTION = -DCPM_LOCAL_PACKAGES_ONLY=ON -DLINGLONG_VERSION=$(DEB_VERSION_UPSTREAM)
 
 ifeq ($(OS) $(VERSION), deepin 23)
-	EXTRA_OPTION += -DENABLE_UAB_HEADER=ON
+	EXTRA_OPTION += -DENABLE_UAB=ON
 
 override_dh_auto_install:
 	dh_auto_install


### PR DESCRIPTION
* Rename ENABLE_UAB_HEADER to ENABLE_UAB.
* If ENABLE_UAB is not set, do not build uab-loader.

Log: