### PR TITLE
chore: failed to link zstd when package linglong

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ pkg_search_module(glib2 REQUIRED IMPORTED_TARGET glib-2.0)
 pkg_search_module(ostree1 REQUIRED IMPORTED_TARGET ostree-1)
 pkg_search_module(systemd REQUIRED IMPORTED_TARGET libsystemd)
 pkg_search_module(ELF REQUIRED IMPORTED_TARGET libelf)
+pkg_search_module(ZSTD REQUIRED IMPORTED_TARGET libzstd)
 
 set(ytj_ENABLE_TESTING NO)
 set(ytj_ENABLE_INSTALL NO)

--- a/libs/linglong/CMakeLists.txt
+++ b/libs/linglong/CMakeLists.txt
@@ -73,6 +73,7 @@ pfl_add_library(
   PkgConfig::ostree1
   PkgConfig::systemd
   PkgConfig::ELF
+  PkgConfig::ZSTD
   Qt5::Concurrent
   Qt5::Core
   Qt5::DBus


### PR DESCRIPTION
add zstd depends to linglong

Log: