### PR TITLE
fix: container env error when environment variables have multiple values

### DIFF
--- a/libs/linglong/src/linglong/runtime/container.cpp
+++ b/libs/linglong/src/linglong/runtime/container.cpp
@@ -85,7 +85,7 @@ Container::run(const ocppi::runtime::config::types::Process &process) noexcept
     }
 
     if (!this->cfg.process->env) {
-        qWarning() << "`env` field is not exists.";
+        qDebug() << "user `env` field is not exists.";
         Q_ASSERT(false);
         this->cfg.process->env = std::vector<std::string>{};
     }


### PR DESCRIPTION
quote the values environment variables to avoid loading errors when some environment variables have multiple values, such as A=a;b

Log: