### PR TITLE
fix: ll-builder convert appimage error when use url

### DIFF
--- a/apps/ll-session-helper/src/main.cpp
+++ b/apps/ll-session-helper/src/main.cpp
@@ -14,8 +14,8 @@
 #include <QTimer>
 #include <unistd.h>
 
-void copyFileToTargetPath(const QFileInfo &fileInfo, QString path);
-void copyDirToTargetPath(const QFileInfo &fileInfo, QString path, QMap<QString, QMap<QString, QDateTime>> &directoryFileTimes);
+void copyFileToTargetPath(const QFileInfo &fileInfo, const QString &path);
+void copyDirToTargetPath(const QFileInfo &fileInfo, const QString &path, QMap<QString, QMap<QString, QDateTime>> &directoryFileTimes);
 
 int main(int argc, char *argv[])
 {

--- a/misc/share/linglong/builder/templates/appimage-url.yaml
+++ b/misc/share/linglong/builder/templates/appimage-url.yaml
@@ -17,6 +17,7 @@ sources:
     digest: '{{{DIGEST}}}'
 
 build: |
+  cd linglong/sources
   APPIMAGE=$(find . -regex '.*\.AppImage\|.*\appimage' -exec basename {} \;)
   chmod +x ${APPIMAGE}
   ./${APPIMAGE} --appimage-extract


### PR DESCRIPTION
url is download to linglong/sources, should enter linglong/sources to operate appimage file

Log: