### PR TITLE
fix: ll-cli install return error errcode

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -636,7 +636,7 @@ int Cli::install(std::map<std::string, docopt::value> &args)
     loop.exec();
 
     updateAM();
-    return 0;
+    return this->lastStatus == service::InstallTask::Success ? 0 : -1;
 }
 
 int Cli::upgrade(std::map<std::string, docopt::value> &args)


### PR DESCRIPTION
ll-cli install(upgrade) should return errcode according to lastStatus

Log: