### PR TITLE
fix: Canceling a task causes the package manager to crash.

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -854,8 +854,6 @@ void PackageManager::CancelTask(const QString &taskID) noexcept
     task->cancelTask();
     task->updateStatus(InstallTask::Canceled,
                        QString{ "cancel installing app %1" }.arg(task->layer()));
-
-    taskList.erase(task);
 }
 
 } // namespace linglong::service


### PR DESCRIPTION
在安装应用时按ctrl+c结束进程, package-manage 会异常退出

Log: